### PR TITLE
Pill View

### DIFF
--- a/Sources/PKSUI/Components/PKSPill/PKSPill.swift
+++ b/Sources/PKSUI/Components/PKSPill/PKSPill.swift
@@ -1,0 +1,165 @@
+//
+//  PKSPill.swift
+//  PKSUI
+//
+//  Created by Omer Hamid Kamisli on 8/17/25.
+//
+
+import SwiftUI
+
+struct PKSPill<Label: View>: View {
+    var action: () -> Void
+    var label: Label
+    
+    var backgroundColor: Color = Color.red
+    var inset: EdgeInsets = EdgeInsets(
+        top: 8,
+        leading: 16,
+        bottom: 8,
+        trailing: 16
+    )
+    
+    init(
+        action: @escaping @MainActor () -> Void,
+        @ViewBuilder label: () -> Label
+    ) {
+        self.action = action
+        self.label = label()
+    }
+    
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            if let label = label as? Text {
+                label
+                    .padding(inset)
+                    .background(backgroundColor, in: Capsule())
+            } else {
+                label
+            }
+        }
+    }
+    
+    public func setInset(_ inset: EdgeInsets) -> Self {
+        map { view in
+            view.inset = inset
+        }
+    }
+    
+    public func setInset(_ edges: Edge.Set, _ lenght: CGFloat) -> Self {
+        map { view in
+            var local = view.inset
+            
+            if edges.contains(.all) {
+                local = EdgeInsets(
+                    top: lenght,
+                    leading: lenght,
+                    bottom: lenght,
+                    trailing: lenght
+                )
+            } else {
+                if edges.contains(.bottom) {
+                    local.bottom = lenght
+                }
+                
+                if edges.contains(.leading) {
+                    local.leading = lenght
+                }
+                
+                if edges.contains(.top) {
+                    local.top = lenght
+                }
+                
+                if edges.contains(.trailing) {
+                    local.trailing = lenght
+                }
+                
+                if edges.contains(.horizontal) {
+                    local.leading = lenght
+                    local.trailing = lenght
+                }
+                
+                if edges.contains(.vertical) {
+                    local.top = lenght
+                    local.bottom = lenght
+                }
+            }
+            
+            
+            view.inset = local
+        }
+    }
+}
+
+extension PKSPill where Label == Text {
+    init<S: StringProtocol> (
+        _ title: S,
+        action: @escaping @MainActor () -> Void
+    ) {
+        label = {
+            Text(title)
+        }()
+        
+        self.action = action
+    }
+}
+
+#Preview {
+    PKSPill {
+        debugPrint("On Tap")
+    } label: {
+        Rectangle()
+            .fill(Color.red)
+            .frame(width: 20, height: 20)
+    }
+    
+    HStack {
+        PKSPill("Hello") {
+            debugPrint("Hello World")
+        }
+        .setInset(
+            EdgeInsets(
+                top: 24,
+                leading: 24,
+                bottom: 24,
+                trailing: 24
+            )
+        )
+        .foregroundStyle(.black)
+        .font(.largeTitle)
+        
+        
+        PKSPill("Hello") {
+            debugPrint("Hello World")
+        }
+        .foregroundStyle(.black)
+        .font(.largeTitle)
+    }
+    
+    PKSPill {
+        debugPrint("On Tap")
+    } label: {
+        HStack {
+            Text("Hello World")
+            Rectangle()
+                .fill(Color.red)
+                .frame(width: 20, height: 20)
+        }
+    }
+    
+    
+    
+    PKSPill {
+        debugPrint("On Tap")
+    } label: {
+        HStack {
+            Rectangle()
+                .fill(Color.red)
+                .frame(width: 20, height: 20)
+            
+            Text("Hello World")
+            
+        }
+    }
+}

--- a/Sources/PKSUI/Components/PKSPill/PKSPill.swift
+++ b/Sources/PKSUI/Components/PKSPill/PKSPill.swift
@@ -7,11 +7,11 @@
 
 import SwiftUI
 
-struct PKSPill<Label: View, Sh: Shape>: View {
+struct PKSPill<L: View, Sh: Shape>: View {
     @Environment(\.isEnabled) var isEnabled
     
     var action: () -> Void
-    var label: Label
+    var label: L
     
     var backgroundColor: Color = Color.red
     var shape: Sh
@@ -24,7 +24,7 @@ struct PKSPill<Label: View, Sh: Shape>: View {
     
     init(
         action: @escaping @MainActor () -> Void,
-        @ViewBuilder label: () -> Label
+        @ViewBuilder label: () -> L
     ) where Sh == Capsule {
         self.action = action
         self.label = label()
@@ -35,7 +35,12 @@ struct PKSPill<Label: View, Sh: Shape>: View {
         Button {
             action()
         } label: {
+            // TODO: Please delete duplicate codes
             if let label = label as? Text {
+                label
+                    .padding(inset)
+                    .background(backgroundColor, in: shape)
+            } else if let label = label as? Label<Text,Image> {
                 label
                     .padding(inset)
                     .background(backgroundColor, in: shape)
@@ -103,7 +108,7 @@ struct PKSPill<Label: View, Sh: Shape>: View {
     }
 }
 
-extension PKSPill where Label == Text {
+extension PKSPill where L == Text {
     init<S: StringProtocol> (
         _ title: S,
         action: @escaping @MainActor () -> Void
@@ -123,6 +128,35 @@ extension PKSPill where Label == Text {
     ) {
         label = {
             Text(title)
+        }()
+        
+        self.action = action
+        self.shape = backgroundShape
+    }
+}
+
+extension PKSPill where L == Label<Text, Image>{
+    init<S: StringProtocol> (
+        _ title: S,
+        systemImage: String,
+        action: @escaping @MainActor () -> Void
+    ) where Sh == Capsule {
+        label = {
+            Label(title, systemImage: systemImage)
+        }()
+        
+        self.action = action
+        self.shape = Capsule()
+    }
+    
+    init<S: StringProtocol> (
+        _ title: S,
+        systemImage: String,
+        backgroundShape: Sh,
+        action: @escaping @MainActor () -> Void
+    ) {
+        label = {
+            Label(title, systemImage: systemImage)
         }()
         
         self.action = action
@@ -186,8 +220,8 @@ extension PKSPill where Label == Text {
         debugPrint("On Tap")
     } label: {
         HStack {
-            Rectangle()
-                .fill(Color.red)
+            Image(systemName: "clock")
+                .resizable()
                 .frame(width: 20, height: 20)
             
             Text("Hello World")
@@ -195,4 +229,8 @@ extension PKSPill where Label == Text {
         }
     }
     .disabled(true)
+    
+    PKSPill("Change Clock", systemImage: "clock") {
+        debugPrint("Clock clicked")
+    }
 }

--- a/Sources/PKSUI/Components/PKSPill/PKSPill.swift
+++ b/Sources/PKSUI/Components/PKSPill/PKSPill.swift
@@ -7,11 +7,14 @@
 
 import SwiftUI
 
-struct PKSPill<Label: View>: View {
+struct PKSPill<Label: View, Sh: Shape>: View {
+    @Environment(\.isEnabled) var isEnabled
+    
     var action: () -> Void
     var label: Label
     
     var backgroundColor: Color = Color.red
+    var shape: Sh
     var inset: EdgeInsets = EdgeInsets(
         top: 8,
         leading: 16,
@@ -22,9 +25,10 @@ struct PKSPill<Label: View>: View {
     init(
         action: @escaping @MainActor () -> Void,
         @ViewBuilder label: () -> Label
-    ) {
+    ) where Sh == Capsule {
         self.action = action
         self.label = label()
+        self.shape = Capsule()
     }
     
     var body: some View {
@@ -34,11 +38,12 @@ struct PKSPill<Label: View>: View {
             if let label = label as? Text {
                 label
                     .padding(inset)
-                    .background(backgroundColor, in: Capsule())
+                    .background(backgroundColor, in: shape)
             } else {
                 label
             }
         }
+        .opacity(isEnabled ? 1 : 0.5)
     }
     
     public func setInset(_ inset: EdgeInsets) -> Self {
@@ -90,11 +95,30 @@ struct PKSPill<Label: View>: View {
             view.inset = local
         }
     }
+    
+    public func backgroundColor(_ color: Color) -> Self {
+        map { view in
+            view.backgroundColor = color
+        }
+    }
 }
 
 extension PKSPill where Label == Text {
     init<S: StringProtocol> (
         _ title: S,
+        action: @escaping @MainActor () -> Void
+    ) where Sh == Capsule {
+        label = {
+            Text(title)
+        }()
+        
+        self.action = action
+        self.shape = Capsule()
+    }
+    
+    init<S: StringProtocol> (
+        _ title: S,
+        backgroundShape: Sh,
         action: @escaping @MainActor () -> Void
     ) {
         label = {
@@ -102,6 +126,7 @@ extension PKSPill where Label == Text {
         }()
         
         self.action = action
+        self.shape = backgroundShape
     }
 }
 
@@ -135,7 +160,14 @@ extension PKSPill where Label == Text {
         }
         .foregroundStyle(.black)
         .font(.largeTitle)
+        
+        PKSPill("Hello", backgroundShape: RoundedRectangle(cornerRadius: 16)) {
+            debugPrint("Hello World")
+        }
+        .foregroundStyle(.black)
+        .font(.body)
     }
+    .disabled(true)
     
     PKSPill {
         debugPrint("On Tap")
@@ -162,4 +194,5 @@ extension PKSPill where Label == Text {
             
         }
     }
+    .disabled(true)
 }

--- a/Sources/PKSUI/ViewModifiers/View+PropertyMapper.swift
+++ b/Sources/PKSUI/ViewModifiers/View+PropertyMapper.swift
@@ -1,0 +1,16 @@
+//
+//  extension.swift
+//  PKSUI
+//
+//  Created by Omer Hamid Kamisli on 8/17/25.
+//
+
+import SwiftUI
+
+extension View {
+    public func map(_ closure: (inout Self) -> Void) -> Self {
+        var copy = self
+        closure(&copy)
+        return copy
+    }
+}


### PR DESCRIPTION
This pull request introduces a new reusable SwiftUI component, `PKSPill`, and a supporting `map` extension on `View` to enable ergonomic property mutation. The main focus is on providing a customizable pill-shaped button with flexible configuration options for label, shape, background color, and insets.

**New Component: PKSPill**

* Added the generic `PKSPill` SwiftUI view, supporting custom labels (`Text`, `Label<Text,Image>`, or any `View`), configurable shape, background color, and padding insets. Includes multiple initializers for common use cases and preview examples.

**View Extension Utility**

* Introduced a `map` extension method for `View` to allow mutation of view properties in a functional style, used internally by `PKSPill` for its configuration methods.


<img width="628" height="1118" alt="CleanShot 2025-08-17 at 11 17 10@2x" src="https://github.com/user-attachments/assets/5e3b384a-b949-42d0-8325-7ed50130e8a7" />
